### PR TITLE
Patch 2

### DIFF
--- a/Clay Frog - Extras Clay Mates
+++ b/Clay Frog - Extras Clay Mates
@@ -1,0 +1,9 @@
+{
+	"project": "Clay Frog - Extras Clay Mates",
+	"tags": [
+		"Clay Frog - Extras Clay Mates"
+	],
+	"policies": [
+		"318a2b2b717e3b7b8c7feb4a3d8855e4c8e73f04b24e7ef1d2a1e00d"
+    ]
+} 

--- a/Hard Fork - Clay Mates
+++ b/Hard Fork - Clay Mates
@@ -1,0 +1,9 @@
+{
+	"project": "Hard Fork - Clay Mates",
+	"tags": [
+		"Hard Fork - Clay Mates"
+	],
+	"policies": [
+		"4b9c44c53a20cdfaec04f6a24dd6572037a54aed27a4647b400255f3"
+	]
+}


### PR DESCRIPTION
Added two policies both are unverified Clay Mates policies I have verified both using Cardanoscan.

I would advise checking with care. 

The policies in question are the "Clay Frog" and the "Hard Fork" policies both of which were "one-off" mints. 