### PR TITLE
Add Policy ID for Saturday's drop and a tag

### DIFF
--- a/Cypherkicks
+++ b/Cypherkicks
@@ -1,5 +1,8 @@
 {
     "project": "Cypherkicks",
+    "tags": [
+        "Cypherkicks"
+    ],
     "policies": [
         "50333947e5b8a45f562c814ab8d28562750e6bdca2b33b09d97d517e",
         "2b1085c9707bf5a18f099a729f45f76e6479158afd3fbd1db9795569",
@@ -12,6 +15,7 @@
         "e7b29ba8e84c428e5840220f65a5b6403d5765b287d0308cbb7ce33d",
         "b24b18473f473244909938297b00137d7690654d88692af4944b3e83",
         "9aa82e078537e34a72acc486070d74646ec6a95c4d9b770e1bd48271",
-        "dd250ccccc8e0f81c50692fd076babf8094f3d5c48c770540fee2fb7"
-    ]
+        "dd250ccccc8e0f81c50692fd076babf8094f3d5c48c770540fee2fb7",
+        "efa591af8a72f86b7020d9b2cb09a5b93468d14f58146f97c680fd25"
+          ]
 }


### PR DESCRIPTION
I'm dropping Season 3 of Cypherkicks on Saturday. More than 1,000 NFTs will be sold under the new policy ID ending on "fd25". 

I also added a tag so people can easily find Cypherkicks NFTs on the website.